### PR TITLE
Handle SimplePay browser returns and harden API client

### DIFF
--- a/includes/class-simplepay-return-handler.php
+++ b/includes/class-simplepay-return-handler.php
@@ -1,0 +1,183 @@
+<?php
+
+use Give\Donations\Models\Donation;
+use Give\Donations\Models\DonationNote;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
+
+/**
+ * Handles SimplePay browser return requests.
+ */
+class SimplePayReturnHandler {
+    /**
+     * Process an onsite listener request and redirect the donor.
+     */
+    public function handleListenerRequest(array $queryParams): void {
+        $donationId = isset($queryParams['donation-id']) ? (int) $queryParams['donation-id'] : 0;
+
+        if (!$donationId) {
+            wp_die(__('Missing donation reference in SimplePay return URL.', 'simplepay-givewp'));
+        }
+
+        $donation = Donation::find($donationId);
+
+        if (!$donation) {
+            wp_die(__('Unable to locate the donation referenced by SimplePay.', 'simplepay-givewp'));
+        }
+
+        try {
+            $redirectUrl = $this->handleDonationReturn($donation, $queryParams, [
+                'success' => $queryParams['success-url'] ?? ($queryParams['givewp-success-url'] ?? ''),
+                'fail' => $queryParams['failure-url'] ?? ($queryParams['givewp-failure-url'] ?? ''),
+                'cancel' => $queryParams['cancel-url'] ?? ($queryParams['givewp-failure-url'] ?? ''),
+                'timeout' => $queryParams['timeout-url'] ?? ($queryParams['givewp-failure-url'] ?? ''),
+            ]);
+        } catch (PaymentGatewayException $exception) {
+            wp_die($exception->getMessage());
+        }
+
+        wp_safe_redirect($redirectUrl);
+        exit;
+    }
+
+    /**
+     * Applies the SimplePay browser return payload to a donation and returns the redirect URL.
+     *
+     * @throws PaymentGatewayException
+     */
+    public function handleDonationReturn(Donation $donation, array $queryParams, array $redirectHints = []): string {
+        $payload = $this->extractPayload($queryParams);
+
+        $event = $payload['e'] ?? '';
+        $transactionId = $payload['t'] ?? '';
+
+        if ($transactionId) {
+            give_update_meta($donation->id, '_simplepay_transaction_id', $transactionId);
+
+            if (empty($donation->gatewayTransactionId)) {
+                $donation->gatewayTransactionId = $transactionId;
+            }
+        }
+
+        $responseCode = $payload['r'] ?? '';
+
+        switch ($event) {
+            case 'SUCCESS':
+                $donation->status = DonationStatus::PROCESSING();
+                $this->addDonationNote($donation, sprintf(
+                    __('SimplePay reported SUCCESS (Transaction ID: %1$s, Result: %2$s). Awaiting IPN for final confirmation.', 'simplepay-givewp'),
+                    $transactionId ?: __('unknown', 'simplepay-givewp'),
+                    $responseCode ?: __('n/a', 'simplepay-givewp')
+                ));
+                break;
+            case 'FAIL':
+                $donation->status = DonationStatus::FAILED();
+                $this->addDonationNote($donation, sprintf(
+                    __('SimplePay reported FAIL (Transaction ID: %1$s, Result: %2$s).', 'simplepay-givewp'),
+                    $transactionId ?: __('unknown', 'simplepay-givewp'),
+                    $responseCode ?: __('n/a', 'simplepay-givewp')
+                ));
+                break;
+            case 'CANCEL':
+                $donation->status = DonationStatus::CANCELLED();
+                $this->addDonationNote($donation, sprintf(
+                    __('SimplePay reported CANCEL (Transaction ID: %1$s).', 'simplepay-givewp'),
+                    $transactionId ?: __('unknown', 'simplepay-givewp')
+                ));
+                break;
+            case 'TIMEOUT':
+                $donation->status = DonationStatus::FAILED();
+                $this->addDonationNote($donation, sprintf(
+                    __('SimplePay reported TIMEOUT (Transaction ID: %1$s).', 'simplepay-givewp'),
+                    $transactionId ?: __('unknown', 'simplepay-givewp')
+                ));
+                break;
+            default:
+                $this->addDonationNote($donation, __('Received SimplePay return without a recognised event code.', 'simplepay-givewp'));
+                break;
+        }
+
+        $donation->save();
+
+        return $this->determineRedirectUrl($event, $redirectHints);
+    }
+
+    /**
+     * Extracts and validates the SimplePay browser return payload from query parameters.
+     *
+     * @throws PaymentGatewayException
+     */
+    private function extractPayload(array $queryParams): array {
+        if (empty($queryParams['r']) || empty($queryParams['s'])) {
+            throw new PaymentGatewayException(__('Missing SimplePay response parameters.', 'simplepay-givewp'));
+        }
+
+        $payload = base64_decode($queryParams['r'], true);
+
+        if ($payload === false) {
+            throw new PaymentGatewayException(__('Failed to decode SimplePay response payload.', 'simplepay-givewp'));
+        }
+
+        $signature = $queryParams['s'];
+
+        if (!$this->verifySignature($payload, $signature)) {
+            throw new PaymentGatewayException(__('Invalid SimplePay response signature.', 'simplepay-givewp'));
+        }
+
+        $data = json_decode($payload, true);
+
+        if (!is_array($data)) {
+            throw new PaymentGatewayException(__('Invalid SimplePay response payload.', 'simplepay-givewp'));
+        }
+
+        return $data;
+    }
+
+    private function verifySignature(string $payload, string $signature): bool {
+        $secretKey = give_get_option('simplepay_secret_key');
+
+        if (!$secretKey) {
+            return false;
+        }
+
+        $calculated = base64_encode(hash_hmac('sha384', $payload, $secretKey, true));
+
+        return hash_equals($calculated, $signature);
+    }
+
+    private function determineRedirectUrl(string $event, array $redirectHints): string {
+        $defaults = [
+            'success' => give_get_success_page_uri(),
+            'fail' => give_get_failed_transaction_uri(),
+            'cancel' => give_get_failed_transaction_uri(),
+            'timeout' => give_get_failed_transaction_uri(),
+        ];
+
+        $redirects = array_merge($defaults, array_filter($redirectHints));
+
+        switch ($event) {
+            case 'SUCCESS':
+                return $this->decodeUrl($redirects['success']);
+            case 'CANCEL':
+                return $this->decodeUrl($redirects['cancel']);
+            case 'TIMEOUT':
+                return $this->decodeUrl($redirects['timeout']);
+            case 'FAIL':
+            default:
+                return $this->decodeUrl($redirects['fail']);
+        }
+    }
+
+    private function decodeUrl(string $url): string {
+        $decoded = rawurldecode($url);
+
+        return $decoded ?: $url;
+    }
+
+    private function addDonationNote(Donation $donation, string $content): void {
+        DonationNote::create([
+            'donationId' => $donation->id,
+            'content' => $content,
+        ]);
+    }
+}

--- a/includes/class-simplepay-webhook-handler.php
+++ b/includes/class-simplepay-webhook-handler.php
@@ -22,7 +22,7 @@ class SimplePayWebhookHandler {
         // Get the signature from the header
         $signature = $this->get_signature_from_header();
         
-        if (!$this->verify_signature($json, $signature)) {
+        if (empty($signature) || !$this->verify_signature($json, $signature)) {
             http_response_code(400);
             exit('Invalid signature');
         }
@@ -42,7 +42,7 @@ class SimplePayWebhookHandler {
         $this->process_ipn_status($ipn_data);
         
         // Send confirmation response
-        $this->send_confirmation($ipn_data, $signature);
+        $this->send_confirmation($ipn_data);
     }
     
     /**
@@ -311,7 +311,7 @@ class SimplePayWebhookHandler {
      * @param array $ipn_data IPN data
      * @param string $received_signature Signature received from SimplePay
      */
-    private function send_confirmation($ipn_data, $received_signature) {
+    private function send_confirmation($ipn_data) {
         // Calculate confirmation signature
         $secret_key = give_get_option('simplepay_secret_key');
         $json_response = json_encode($ipn_data);

--- a/simplepay-gateway.php
+++ b/simplepay-gateway.php
@@ -23,6 +23,7 @@ define('SIMPLEPAY_GIVEWP_URL', plugin_dir_url(__FILE__));
 add_action('givewp_register_payment_gateway', static function ($paymentGatewayRegister) {
     require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-api-client.php';
     require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-webhook-handler.php';
+    require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-return-handler.php';
     require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-onsite-gateway.php';
     require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-offsite-gateway.php';
     
@@ -51,6 +52,11 @@ add_action('init', function () {
         $webhook_handler = new SimplePayWebhookHandler();
         $webhook_handler->process_webhook();
         exit;
+    }
+    if (isset($_GET['give-listener']) && $_GET['give-listener'] === 'simplepay-return') {
+        require_once SIMPLEPAY_GIVEWP_DIR . 'includes/class-simplepay-return-handler.php';
+        $return_handler = new SimplePayReturnHandler();
+        $return_handler->handleListenerRequest($_GET);
     }
 });
 


### PR DESCRIPTION
## Summary
- add a dedicated SimplePay return handler to verify signed browser payloads and drive donor messaging/redirects
- update onsite and offsite gateways to submit documented `urls`, reuse the return handler, and capture redirect targets
- harden the API client and webhook handler with better transport error handling and signature validation

## Testing
- php -l includes/class-simplepay-api-client.php
- php -l includes/class-simplepay-onsite-gateway.php
- php -l includes/class-simplepay-offsite-gateway.php
- php -l includes/class-simplepay-return-handler.php
- php -l includes/class-simplepay-webhook-handler.php
- php -l simplepay-gateway.php

------
https://chatgpt.com/codex/tasks/task_e_68df91c70d90832bb3d5dc75c1cb505f